### PR TITLE
Fußnotennummerierung korrigiert

### DIFF
--- a/Latex/vorlage/vorlage.tex
+++ b/Latex/vorlage/vorlage.tex
@@ -29,6 +29,7 @@
 \usepackage{chngcntr}
 \counterwithout{figure}{chapter}
 \counterwithout{table}{chapter}
+\counterwithout{footnote}{chapter}
 \RedeclareSectionCommand[style=section,afterskip=.15em]{chapter}
 \setcounter{secnumdepth}{\subsubsectionnumdepth}
 \setcounter{tocdepth}{\subsubsectionnumdepth}


### PR DESCRIPTION
Nummerierung der Fußnoten wurde mit jedem Kapitel zurückgesetzt - behoben