### PR TITLE
Vspace vor Minted Umgebungen (und weniger militante Positionierung)

### DIFF
--- a/Latex/vorlage/vorlage_subs/minted.tex
+++ b/Latex/vorlage/vorlage_subs/minted.tex
@@ -31,7 +31,7 @@
   type=code,                           % Name der Umgebung
   types=codes,                         % Erweiterung (\listofschemes)
   float,                               % soll gleiten
-  floatpos=H,
+  floatpos=h,
   tocentryentrynumberformat=\bfseries, % voreingestellte Gleitparameter
   name=Code,                           % Name in Überschriften
   listname={Programmcodeverzeichnis},  % Listenname
@@ -44,3 +44,4 @@
   \autodot{\space\space\space}
 }
 \BeforeStartingTOC[loc]{\renewcommand*\autodot{\space\space\space\space}}
+\AtBeginEnvironment{minted}{\vspace{\baselineskip}}


### PR DESCRIPTION
vorher:
![grafik](https://user-images.githubusercontent.com/24256864/179931625-6c27af90-b646-4f91-8a15-e062e7c8a87d.png)
nachher:
![grafik](https://user-images.githubusercontent.com/24256864/179931676-12dca028-813e-4183-82e3-76cda4776e6e.png)

außerdem wird die Code-Float Position auf "h" gesetzt (statt "H"). In Situationen in denen das einen Unterschied macht, sollte h wahrscheinlich eh besser aussehen... H sollte nur eine manuelle Notfalloption sein