### PR TITLE
Geänderte Platzierung

### DIFF
--- a/HINWEISE.md
+++ b/HINWEISE.md
@@ -28,7 +28,7 @@ Hier befinden sich einige Hinweise dazu, wie verschiedene Anforderungen der HAWA
     - Nach der Float-Umgebung, muss entweder mit `\footnotetext{Die gewünschte Fußnote}` oder mit `\vgcaption{Link}{Datum}` der entsprechende Fußnotentext gesetzt werden. 
     - Beispiel mit `\vgcaption`:
         ```tex
-        \begin{code}[hptb]
+        \begin{code}[H]
         \linkcaption{Beispielcode}
         \label{code:example2}
         \end{code}
@@ -36,7 +36,7 @@ Hier befinden sich einige Hinweise dazu, wie verschiedene Anforderungen der HAWA
         ```
     - **Besonderheit:** Soll die Fußnote im Text der Caption stehen, ist eine andere Vorgehensweise nötig (ausführlich: https://tex.stackexchange.com/questions/10181/using-footnote-in-a-figures-caption):
         ```tex
-        \begin{code}[hptb]
+        \begin{code}[H]
         \caption[Caption ohne Fußnote]{Caption mit\footnotemark Fußnote}
         \end{code}
         \footnotetext{Text der Fußnote}
@@ -59,7 +59,7 @@ Hier befinden sich einige Hinweise dazu, wie verschiedene Anforderungen der HAWA
 ## Float-Umgebungen (Code, Verzeichnisse, usw.)
 - Soll Programmcode in der Arbeit angezeigt bzw. eingebunden werden so steht dafür nun die Umgebung `\begin{code}` zur Verfügung. Der genaue Syntax ist folgender:
     ```tex
-    \begin{code}[hptb]
+    \begin{code}[H]
         \inputminted[
             firstline=27,
             lastline=37,

--- a/HINWEISE.md
+++ b/HINWEISE.md
@@ -28,7 +28,7 @@ Hier befinden sich einige Hinweise dazu, wie verschiedene Anforderungen der HAWA
     - Nach der Float-Umgebung, muss entweder mit `\footnotetext{Die gewünschte Fußnote}` oder mit `\vgcaption{Link}{Datum}` der entsprechende Fußnotentext gesetzt werden. 
     - Beispiel mit `\vgcaption`:
         ```tex
-        \begin{code}[h]
+        \begin{code}[hptb]
         \linkcaption{Beispielcode}
         \label{code:example2}
         \end{code}
@@ -36,7 +36,7 @@ Hier befinden sich einige Hinweise dazu, wie verschiedene Anforderungen der HAWA
         ```
     - **Besonderheit:** Soll die Fußnote im Text der Caption stehen, ist eine andere Vorgehensweise nötig (ausführlich: https://tex.stackexchange.com/questions/10181/using-footnote-in-a-figures-caption):
         ```tex
-        \begin{code}[h]
+        \begin{code}[hptb]
         \caption[Caption ohne Fußnote]{Caption mit\footnotemark Fußnote}
         \end{code}
         \footnotetext{Text der Fußnote}
@@ -59,7 +59,7 @@ Hier befinden sich einige Hinweise dazu, wie verschiedene Anforderungen der HAWA
 ## Float-Umgebungen (Code, Verzeichnisse, usw.)
 - Soll Programmcode in der Arbeit angezeigt bzw. eingebunden werden so steht dafür nun die Umgebung `\begin{code}` zur Verfügung. Der genaue Syntax ist folgender:
     ```tex
-    \begin{code}[h]
+    \begin{code}[hptb]
         \inputminted[
             firstline=27,
             lastline=37,

--- a/Latex/inhalt/Anhang.tex
+++ b/Latex/inhalt/Anhang.tex
@@ -21,7 +21,7 @@
 %! Anpassung der Darstellung von Abbildungen im Anhang
 %! Eine Variante auskommentieren
 %? Möglichkeit 1: ohne Nummerierung
-%\renewcommand{\bild}[4][1.0]{\begin{figure}[h]
+%\renewcommand{\bild}[4][1.0]{\begin{figure}[hptb]
     %\centering
     %\includegraphics[width=#1\columnwidth]{bilder/#2}
     %\caption*{\bfseries Abbildung \mdseries #3}
@@ -29,7 +29,7 @@
     %\end{figure}}
 
 %? Möglichkeit 2: mit Nummerierung aber nicht im Abbildungsverzeichnis
-\renewcommand{\bild}[4][1.0]{\begin{figure}[h]
+\renewcommand{\bild}[4][1.0]{\begin{figure}[hptb]
     \centering
     \includegraphics[width=#1\columnwidth]{bilder/#2}
     \caption[]{#3}

--- a/Latex/inhalt/Anhang.tex
+++ b/Latex/inhalt/Anhang.tex
@@ -21,7 +21,7 @@
 %! Anpassung der Darstellung von Abbildungen im Anhang
 %! Eine Variante auskommentieren
 %? Möglichkeit 1: ohne Nummerierung
-%\renewcommand{\bild}[4][1.0]{\begin{figure}[hptb]
+%\renewcommand{\bild}[4][1.0]{\begin{figure}[H]
     %\centering
     %\includegraphics[width=#1\columnwidth]{bilder/#2}
     %\caption*{\bfseries Abbildung \mdseries #3}
@@ -29,7 +29,7 @@
     %\end{figure}}
 
 %? Möglichkeit 2: mit Nummerierung aber nicht im Abbildungsverzeichnis
-\renewcommand{\bild}[4][1.0]{\begin{figure}[hptb]
+\renewcommand{\bild}[4][1.0]{\begin{figure}[H]
     \centering
     \includegraphics[width=#1\columnwidth]{bilder/#2}
     \caption[]{#3}

--- a/Latex/light/vorlage_light.tex
+++ b/Latex/light/vorlage_light.tex
@@ -84,7 +84,7 @@
   type=code,                         % Name der Umgebung
   types=codes,                       % Erweiterung (\listofschemes)
   float,                               % soll gleiten
-  floatpos=hptb,
+  floatpos=H,
   tocentryentrynumberformat=\bfseries,                        % voreingestellte Gleitparameter
   name=Code,                         % Name in Überschriften
   listname={Programmcodeverzeichnis}, % Listenname
@@ -220,7 +220,7 @@
 
 % ? Ab hier beginnen eigene Befehle um den Umgang zu erleichtern
 \newcommand{\logisch}[1]{$``#1``$}
-\newcommand{\bild}[4][1.0]{\begin{figure}[hptb]
+\newcommand{\bild}[4][1.0]{\begin{figure}[H]
                       \centering
                       \includegraphics[width=#1\columnwidth]{bilder/#2}
                       \caption{#3}
@@ -229,7 +229,7 @@
 \newcommand{\striche}[1]{\glqq #1\grqq{}}
 \newcommand{\vglink}[2]{\footnote{\hspace{0.5em}vgl.~\href{#1}{#1}~(#2)}}
 \newcommand{\python}[1]{\mintinline{python}{#1}}
-\newcommand{\svg}[4][1.0]{\begin{figure}[hptb]
+\newcommand{\svg}[4][1.0]{\begin{figure}[H]
   \centering
   \includesvg[width=#1\columnwidth,inkscapelatex=false]{bilder/#2}
   \caption{#3}

--- a/Latex/light/vorlage_light.tex
+++ b/Latex/light/vorlage_light.tex
@@ -84,7 +84,7 @@
   type=code,                         % Name der Umgebung
   types=codes,                       % Erweiterung (\listofschemes)
   float,                               % soll gleiten
-  floatpos=H,
+  floatpos=hptb,
   tocentryentrynumberformat=\bfseries,                        % voreingestellte Gleitparameter
   name=Code,                         % Name in Überschriften
   listname={Programmcodeverzeichnis}, % Listenname
@@ -220,7 +220,7 @@
 
 % ? Ab hier beginnen eigene Befehle um den Umgang zu erleichtern
 \newcommand{\logisch}[1]{$``#1``$}
-\newcommand{\bild}[4][1.0]{\begin{figure}[h]
+\newcommand{\bild}[4][1.0]{\begin{figure}[hptb]
                       \centering
                       \includegraphics[width=#1\columnwidth]{bilder/#2}
                       \caption{#3}
@@ -229,7 +229,7 @@
 \newcommand{\striche}[1]{\glqq #1\grqq{}}
 \newcommand{\vglink}[2]{\footnote{\hspace{0.5em}vgl.~\href{#1}{#1}~(#2)}}
 \newcommand{\python}[1]{\mintinline{python}{#1}}
-\newcommand{\svg}[4][1.0]{\begin{figure}[h]
+\newcommand{\svg}[4][1.0]{\begin{figure}[hptb]
   \centering
   \includesvg[width=#1\columnwidth,inkscapelatex=false]{bilder/#2}
   \caption{#3}

--- a/Latex/vorlage/Doku-Test.tex
+++ b/Latex/vorlage/Doku-Test.tex
@@ -18,7 +18,7 @@ Siehe Quelltext.\fn{Dort wird das Kommando \striche{bild} aufgeführt. In dieser
 Siehe Quelltext.
 %\svg[0.5]{dateiname-ohne-endung}{Text zu einer \ac{SVG}-Datei}{label2}
 \section{Programmcode}
-\begin{code}[hptb]
+\begin{code}[H]
     \begin{minted}{python}
         import asdf
         from foo import bar
@@ -41,7 +41,7 @@ Dies kann genutzt werden, wenn man nur kurz auf eine Funktion eingehen möchte u
 
 Ein weiterer Code um zu schauen, ob danach die Zeilennummerierung wieder funktioniert.
 
-\begin{code}[hptb]
+\begin{code}[H]
   \begin{minted}{python}
       class Wooo(Foo):
           def __init__(self, boo):
@@ -92,7 +92,7 @@ Ein weiterer Code um zu schauen, ob danach die Zeilennummerierung wieder funktio
 
 \chapter{Test-/Dokutabelle}
 Diese Tabelle dient hauptsächlich zum Testen der einzelnen Kommandos, sowie als minimales Beispiel für eine \emph{tabularx}-Tabelle:
-\begin{table}[hptb]
+\begin{table}[H]
 \begin{tabularx}{\columnwidth}{|p{3cm}|X|p{.2\columnwidth}|}
 \hline
 Gegenstand & Beispiel & Anmerkungen \\

--- a/Latex/vorlage/Doku-Test.tex
+++ b/Latex/vorlage/Doku-Test.tex
@@ -18,7 +18,7 @@ Siehe Quelltext.\fn{Dort wird das Kommando \striche{bild} aufgeführt. In dieser
 Siehe Quelltext.
 %\svg[0.5]{dateiname-ohne-endung}{Text zu einer \ac{SVG}-Datei}{label2}
 \section{Programmcode}
-\begin{code}[h]
+\begin{code}[hptb]
     \begin{minted}{python}
         import asdf
         from foo import bar
@@ -41,7 +41,7 @@ Dies kann genutzt werden, wenn man nur kurz auf eine Funktion eingehen möchte u
 
 Ein weiterer Code um zu schauen, ob danach die Zeilennummerierung wieder funktioniert.
 
-\begin{code}[h]
+\begin{code}[hptb]
   \begin{minted}{python}
       class Wooo(Foo):
           def __init__(self, boo):
@@ -89,7 +89,7 @@ Ein weiterer Code um zu schauen, ob danach die Zeilennummerierung wieder funktio
 
 \chapter{Test-/Dokutabelle}
 Diese Tabelle dient hauptsächlich zum Testen der einzelnen Kommandos, sowie als minimales Beispiel für eine \emph{tabularx}-Tabelle:
-\begin{table}[h]
+\begin{table}[hptb]
 \begin{tabularx}{\columnwidth}{|p{3cm}|X|p{.2\columnwidth}|}
 \hline
 Gegenstand & Beispiel & Anmerkungen \\

--- a/Latex/vorlage/Doku-Test.tex
+++ b/Latex/vorlage/Doku-Test.tex
@@ -53,6 +53,9 @@ Ein weiterer Code um zu schauen, ob danach die Zeilennummerierung wieder funktio
 \end{code}
 \vgcaption{https://link-wo-es-den-code-gibt.de}{06.07.2022}
 \section{Ordnerstruktur}
+    In diesem Abschnitt wird eine Ordnerstruktur in \litebref{beispielbaum} gezeigt.
+    Ordnerstrukturen können im Quellcode definiert werden.
+    Die Symbole für Ordner und Dateien können, auf Wunsch, ausgetauscht oder erweitert werden, um verschiedene Dateitypen abzubilden.
     \verzeichnis{%
           .1 \dtfolder Vorlage-Latex. .2 \dtfile HINWEISE.md.
           .2 \dtfile LICENSE.

--- a/Latex/vorlage/vorlage_subs/custom_commands.tex
+++ b/Latex/vorlage/vorlage_subs/custom_commands.tex
@@ -7,7 +7,7 @@
 % Umgebungen u.Ä.
 \newcommand{\fn}[1]{\footnote{\hspace{0.5em}#1}}
 %! #1 - Breite, #2 - Dateiname, #3 Caption, #4 - Label
-\newcommand{\bild}[4][1.0]{\begin{figure}[hptb]
+\newcommand{\bild}[4][1.0]{\begin{figure}[H]
   \centering
   \includegraphics[width=#1\columnwidth]{bilder/#2}
   \caption{#3}
@@ -15,14 +15,14 @@
   \end{figure}}
 \newcommand{\striche}[1]{\glqq #1\grqq{}}
 %! #1 - Breite, #2 - Dateiname, #3 Caption, #4 - Label
-\newcommand{\svg}[4][1.0]{\begin{figure}[hptb]
+\newcommand{\svg}[4][1.0]{\begin{figure}[H]
     \centering
     \includesvg[width=#1\columnwidth,inkscapelatex=false]{bilder/#2}
     \caption{#3}
     \label{#4}
     \end{figure}}
 %! #1 - Dirtree, #2 - Caption, #3 - Label
-\newcommand{\verzeichnis}[3]{\begin{figure}[hptb]
+\newcommand{\verzeichnis}[3]{\begin{figure}[H]
   % https://tex.stackexchange.com/a/99591/220899
   \renewcommand{\DTstyle}{\textrm\expandafter\raisebox{-0.7ex}}
   \centering
@@ -40,7 +40,7 @@
 \newcommand{\vgcaption}[2]{\footnotetext{\hspace{0.5em}vgl.~\href{#1}{#1}~(#2)}}
 \newcommand{\python}[1]{\mintinline{python}{#1}}
 %! #1 - Formel, #2 - Legende, #3 - Caption, #4 - Label
-\newcommand{\formula}[4]{\begin{formel}[hptb]
+\newcommand{\formula}[4]{\begin{formel}[H]
   \pretocmd{\captionbelow}{\onelinecaptionstrue}{}{}
   \KOMAoptions{captions=centeredbeside}
   \begin{captionbeside}[#3]{\textbf{#3}}[r]#1\end{captionbeside}

--- a/Latex/vorlage/vorlage_subs/custom_commands.tex
+++ b/Latex/vorlage/vorlage_subs/custom_commands.tex
@@ -7,7 +7,7 @@
 % Umgebungen u.Ä.
 \newcommand{\fn}[1]{\footnote{\hspace{0.5em}#1}}
 %! #1 - Breite, #2 - Dateiname, #3 Caption, #4 - Label
-\newcommand{\bild}[4][1.0]{\begin{figure}[h]
+\newcommand{\bild}[4][1.0]{\begin{figure}[hptb]
   \centering
   \includegraphics[width=#1\columnwidth]{bilder/#2}
   \caption{#3}
@@ -15,7 +15,7 @@
   \end{figure}}
 \newcommand{\striche}[1]{\glqq #1\grqq{}}
 %! #1 - Breite, #2 - Dateiname, #3 Caption, #4 - Label
-\newcommand{\svg}[4][1.0]{\begin{figure}[h]
+\newcommand{\svg}[4][1.0]{\begin{figure}[hptb]
     \centering
     \includesvg[width=#1\columnwidth,inkscapelatex=false]{bilder/#2}
     \caption{#3}
@@ -40,7 +40,7 @@
 \newcommand{\vgcaption}[2]{\footnotetext{\hspace{0.5em}vgl.~\href{#1}{#1}~(#2)}}
 \newcommand{\python}[1]{\mintinline{python}{#1}}
 %! #1 - Formel, #2 - Legende, #3 - Caption, #4 - Label
-\newcommand{\formula}[4]{\begin{formel}[h]
+\newcommand{\formula}[4]{\begin{formel}[hptb]
   \pretocmd{\captionbelow}{\onelinecaptionstrue}{}{}
   \KOMAoptions{captions=centeredbeside}
   \begin{captionbeside}[#3]{\textbf{#3}}[r]#1\end{captionbeside}

--- a/Latex/vorlage/vorlage_subs/custom_commands.tex
+++ b/Latex/vorlage/vorlage_subs/custom_commands.tex
@@ -22,7 +22,7 @@
     \label{#4}
     \end{figure}}
 %! #1 - Dirtree, #2 - Caption, #3 - Label
-\newcommand{\verzeichnis}[3]{\begin{figure}[H]
+\newcommand{\verzeichnis}[3]{\begin{figure}[hptb]
   % https://tex.stackexchange.com/a/99591/220899
   \renewcommand{\DTstyle}{\textrm\expandafter\raisebox{-0.7ex}}
   \centering

--- a/Latex/vorlage/vorlage_subs/minted.tex
+++ b/Latex/vorlage/vorlage_subs/minted.tex
@@ -32,7 +32,7 @@
   type=code,                           % Name der Umgebung
   types=codes,                         % Erweiterung (\listofschemes)
   float,                               % soll gleiten
-  floatpos=h,
+  floatpos=hptb,
   tocentryentrynumberformat=\bfseries, % voreingestellte Gleitparameter
   name=Code,                           % Name in Überschriften
   listname={Programmcodeverzeichnis},  % Listenname

--- a/Latex/vorlage/vorlage_subs/minted.tex
+++ b/Latex/vorlage/vorlage_subs/minted.tex
@@ -32,7 +32,7 @@
   type=code,                           % Name der Umgebung
   types=codes,                         % Erweiterung (\listofschemes)
   float,                               % soll gleiten
-  floatpos=hptb,
+  floatpos=H,
   tocentryentrynumberformat=\bfseries, % voreingestellte Gleitparameter
   name=Code,                           % Name in Überschriften
   listname={Programmcodeverzeichnis},  % Listenname


### PR DESCRIPTION
fixes #211

ähnlich wie von @ParkerSnable vorgeschlagen, habe ich die Platzierung auf `hptb` geändert.
Das ist immernoch weit weniger militant als `H`, priorisiert aber die gleiche Seite höher als `h`.
In der Doku-Test hat es dafür gesorgt, dass ich (mit etwas zusätzlichem Text) Verzeichnisbäume umstellen konnte, in meiner Bachelorthesis hat sich dadurch gegenüber `h` (dem aktuellen stand auf dev) absolut nichts geändert. Ich sehe also keine Nachteile.