### PR TITLE
Vereinfachung der Ref-Commands

### DIFF
--- a/HINWEISE.md
+++ b/HINWEISE.md
@@ -14,11 +14,8 @@ Hier befinden sich einige Hinweise dazu, wie verschiedene Anforderungen der HAWA
 
 - Fußnoten sollten durch `\fn{Fußnotentext}`, Online-Zitate durch `\onlinezitat{key}`, andere Zitate durch `\zitat[Seite]{key}` eingetragen werden. Beispiele dazu, wie Quellen zu speichern sind, sind in `literatur.bib` zu finden. Außerdem existieren äquivalente Befehle für sinngemäße Zitate: `\vgonlinezitat{key}` bzw. `\vgzitat[Seite]{key}`. In `Doku-Test.tex` sind Beispiele zur Nutzung zu finden.
 
-- Mit `\label{bezeichner:name}` können Bezeichner für Elemente erstellt werden. Auf diese kann über LaTeX-eigene oder in `vorlage/vorlage-commands.tex` definierte Kommandos zugegriffen werden.
-    - Die vordefinierten Kommandos sind folgendermaßen aufgebaut:
-        - Universelle Kommandos für kurze (`\uniliteref`) bzw. lange (`\unifullref`) Referenzen
-        - Typ-spezifische Varianten davon (`\litearef` bzw. `\fullaref`) für Anhänge (a), Abbildungen (b), Codes (c), Formeln (f), Kapitel (=Sektionen, s) unt Tabellen (t)
-        - Kurz-Versionen der `lite`-Kommandos, z.B. `\cref` um `\litecref` und dadurch `\uniliteref{Code}` auszulösen
+- Mit `\label{bezeichner:name}` können Bezeichner für Elemente erstellt werden. Auf diese kann über LaTeX-eigene oder in `vorlage/vorlage-commands.tex` definierte Kommandos `\literef` und `\fullref` zugegriffen werden.
+Für weitere Details zu Referenzen siehe `Doku-Test.tex` bzw. die standardmäßig daraus generierte PDF.
 
 - `\vglink{url}{datum}` erzeugt eine Fußnote mit vgl. link (xx.xx.2020) nach der gültigen Formatierung
 

--- a/Latex/vorlage/Doku-Test.tex
+++ b/Latex/vorlage/Doku-Test.tex
@@ -53,7 +53,7 @@ Ein weiterer Code um zu schauen, ob danach die Zeilennummerierung wieder funktio
 \end{code}
 \vgcaption{https://link-wo-es-den-code-gibt.de}{06.07.2022}
 \section{Ordnerstruktur}
-    In diesem Abschnitt wird eine Ordnerstruktur in \litebref{beispielbaum} gezeigt.
+    In diesem Abschnitt wird eine Ordnerstruktur in \literef{beispielbaum} gezeigt.
     Ordnerstrukturen können im Quellcode definiert werden.
     Die Symbole für Ordner und Dateien können, auf Wunsch, ausgetauscht oder erweitert werden, um verschiedene Dateitypen abzubilden.
     \verzeichnis{%
@@ -92,26 +92,17 @@ Ein weiterer Code um zu schauen, ob danach die Zeilennummerierung wieder funktio
 
 \chapter{Test-/Dokutabelle}
 Diese Tabelle dient hauptsächlich zum Testen der einzelnen Kommandos, sowie als minimales Beispiel für eine \emph{tabularx}-Tabelle:
+\hbadness=10000 %"Tabelle 1" in Spalte Beispiel erzeugt sonst eine Warnung
 \begin{table}[H]
 \begin{tabularx}{\columnwidth}{|p{3cm}|X|p{.2\columnwidth}|}
 \hline
-Gegenstand & Beispiel & Anmerkungen \\
+Gegenstand & Beispiel & Befehl \\
 \hline
-Kurzer Verweis auf Kapitel & \literef{sec:beispiele} & \\
+Kurzer Verweis & \literef{sec:beispiele} & \emph{\textbackslash literef}\\
 \hline
-Kurzer Verweis auf Anhang & \litearef{cd-inhalt} & Alias: \emph{\textbackslash aref} \\
+Langer Verweis & \fullref{beispielbaum} & \emph{\textbackslash fullref}\\
 \hline
-Kurzer Verweis auf Abbildung & \litebref{beispielbaum} & Alias: \emph{\textbackslash bref} \\
-\hline
-Kurzer Verweis auf Tabelle & \litetref{beispieltabelle} & Alias: \emph{\textbackslash tref} \\
-\hline
-Langer Verweis auf Kapitel & \fullref{sec:beispiele} & \\
-\hline
-Langer Verweis auf Anhang & \fullaref{cd-inhalt} &  \\
-\hline
-Langer Verweis auf Abbildung & \fullbref{beispielbaum} &  \\
-\hline
-Langer Verweis auf Tabelle & \fulltref{beispieltabelle} &  \\
+Verweis ohne Objektname & \autoref{beispieltabelle} & \emph{\textbackslash autoref}\\
 \hline
 \multicolumn{2}{|c|}{verbundene Spalten mit zentriertem Text} & \emph{\textbackslash multicolumn} \\
 \hline
@@ -123,5 +114,6 @@ Zeile 2 & & mit \emph{\textbackslash hsize}\\
 \caption{Beispieltabelle}
 \label{beispieltabelle}
 \end{table}
+\hbadness=1000
 
 In diesem Satz wird eine Quelle mit nur einem Autor zitiert\onlinezitat{HAWA}, eine Quelle mit drei Autoren\vgonlinezitat{Vorlage} wird sinngemäß zitiert und eine Quelle mit vier Autoren\onlinezitat[Abs.~2.3]{rfc3596}, welche als \emph{Autor 1; u.a.} dargestellt werden sollte, existiert ebenfalls. Es folgen ein Buch-Zitat mit Seitenangabe\zitat[9]{KOHM2020} und ein sinngemäßes Zitat aus einer unveröffentlichten Quelle\vguvzitat{UV}.

--- a/Latex/vorlage/vorlage_subs/custom_commands.tex
+++ b/Latex/vorlage/vorlage_subs/custom_commands.tex
@@ -52,29 +52,24 @@
 \newcommand{\fullref}[1]{(\emph{\hyperref[{#1}]{siehe \autoref{#1} - \nameref{#1}}})}
 
 % Kompatibilität zu alter "Architektur"
-\newcommand{\litearef}[1]{\literef{#1}}
-\newcommand{\fullaref}[1]{\fullref{#1}}
-\newcommand{\aref}[1]{\litearef{#1}}
-% Abbildungen
-\newcommand{\litebref}[1]{\literef{#1}}
-\newcommand{\fullbref}[1]{\fullref{#1}}
-\newcommand{\bref}[1]{\litebref{#1}}
-% Code
-\newcommand{\litecref}[1]{\literef{#1}}
-\newcommand{\fullcref}[1]{\fullref{#1}}
-\newcommand{\cref}[1]{\litecref{#1}}
-% Formeln
-\newcommand{\litefref}[1]{\literef{#1}}
-\newcommand{\fullfref}[1]{\fullref{#1}}
-\newcommand{\fref}[1]{\litefref{#1}}
-% Kapitel
-\newcommand{\fullsref}[1]{\fullref{#1}}
-\newcommand{\litesref}[1]{\literef{#1}}
-\newcommand{\sref}[1]{\litesref{#1}}
-% Tabellen
-\newcommand{\litetref}[1]{\literef{#1}}
-\newcommand{\fulltref}[1]{\fullref{#1}}
-\newcommand{\tref}[1]{\litetref{#1}}
+\let\aref\literef
+\let\bref\literef
+\let\cref\literef
+\let\fref\literef
+\let\sref\literef
+\let\tref\literef
+\let\litearef\literef
+\let\litebref\literef
+\let\litecref\literef
+\let\litefref\literef
+\let\litesref\literef
+\let\litetref\literef
+\let\fullaref\fullref
+\let\fullbref\fullref
+\let\fullcref\fullref
+\let\fullfref\fullref
+\let\fullsref\fullref
+\let\fulltref\fullref
 
 % automatische Ermittlung des ref-Typs nach https://tex.stackexchange.com/questions/33776/get-label-target-type
 \makeatletter

--- a/Latex/vorlage/vorlage_subs/custom_commands.tex
+++ b/Latex/vorlage/vorlage_subs/custom_commands.tex
@@ -47,35 +47,85 @@
   \begin{captionbeside}[#3]{\textbf{#3}}[r]#1\end{captionbeside}
   \pretocmd{\captionbelow}{}{}{}#2\label{#4}\end{formel}}
 
-% Referenzierung
-\newcommand{\uniliteref}[2]{\emph{\hyperref[{#2}]{#1 \ref{#2} - \nameref{#2}}}}
-\newcommand{\unifullref}[2]{(\emph{\hyperref[{#2}]{siehe #1 \ref{#2} - \nameref{#2}}})}
+%! Referenzierung
+\newcommand{\literef}[1]{\emph{\hyperref[{#1}]{\autoref{#1} - \nameref{#1}}}}
+\newcommand{\fullref}[1]{(\emph{\hyperref[{#1}]{siehe \autoref{#1} - \nameref{#1}}})}
 
-% Anhänge - Sonderbehandlung, da nameref auf Anhänge nicht funktioniert
-% https://github.com/DSczyrba/Vorlage-Latex/issues/29
-\newcommand{\litearef}[1]{\uniliteref{Anhang}{#1}}
-\newcommand{\fullaref}[1]{\unifullref{Anhang}{#1}}
+% Kompatibilität zu alter "Architektur"
+\newcommand{\litearef}[1]{\literef{#1}}
+\newcommand{\fullaref}[1]{\fullref{#1}}
 \newcommand{\aref}[1]{\litearef{#1}}
 % Abbildungen
-\newcommand{\litebref}[1]{\uniliteref{Abbildung}{#1}}
-\newcommand{\fullbref}[1]{\unifullref{Abbildung}{#1}}
+\newcommand{\litebref}[1]{\literef{#1}}
+\newcommand{\fullbref}[1]{\fullref{#1}}
 \newcommand{\bref}[1]{\litebref{#1}}
 % Code
-\newcommand{\litecref}[1]{\uniliteref{Code}{#1}}
-\newcommand{\fullcref}[1]{\unifullref{Code}{#1}}
+\newcommand{\litecref}[1]{\literef{#1}}
+\newcommand{\fullcref}[1]{\fullref{#1}}
 \newcommand{\cref}[1]{\litecref{#1}}
 % Formeln
-\newcommand{\litefref}[1]{\uniliteref{Formel}{#1}}
-\newcommand{\fullfref}[1]{\unifullref{Formel}{#1}}
+\newcommand{\litefref}[1]{\literef{#1}}
+\newcommand{\fullfref}[1]{\fullref{#1}}
 \newcommand{\fref}[1]{\litefref{#1}}
 % Kapitel
-\newcommand{\fullsref}[1]{\unifullref{Kapitel}{#1}}
-\newcommand{\litesref}[1]{\uniliteref{Kapitel}{#1}}
+\newcommand{\fullsref}[1]{\fullref{#1}}
+\newcommand{\litesref}[1]{\literef{#1}}
 \newcommand{\sref}[1]{\litesref{#1}}
 % Tabellen
-\newcommand{\litetref}[1]{\uniliteref{Tabelle}{#1}}
-\newcommand{\fulltref}[1]{\unifullref{Tabelle}{#1}}
+\newcommand{\litetref}[1]{\literef{#1}}
+\newcommand{\fulltref}[1]{\fullref{#1}}
 \newcommand{\tref}[1]{\litetref{#1}}
-% Kompatibilität
-\newcommand{\literef}[1]{\litesref{#1}}
-\newcommand{\fullref}[1]{\fullsref{#1}}
+
+% automatische Ermittlung des ref-Typs nach https://tex.stackexchange.com/questions/33776/get-label-target-type
+\makeatletter
+
+% Helper macro to extract the type (section,subsection...) or the type name
+% out of the label reference. Works with hyperref only.
+% Argument #1 is a macro of form \def\...#1...\@nil{...}
+% Argument #2 is the label reference, e.g. "sect:test"
+\newcommand*\@autoref[2]{% \HyPsd@@@autoref from hyperref, modified
+  \expandafter\ifx\csname r@#2\endcsname\relax
+    ??%
+  \else
+    \expandafter\expandafter\expandafter\@@autoref
+        \csname r@#2\endcsname{}{}{}{}\@nil#1\@nil
+  \fi
+}
+\def\@@autoref#1#2#3#4#5\@nil#6\@nil{% \HyPsd@autorefname, modified
+  #6#4.\@nil}% Argument #4 = type and number, e.g. "section.1" or "subsection.1.2"
+
+% \reftype results in the type name, e.g. "section" or "figure".
+% The starred variant will remove a star, if existent, i.e. "section*" will become "section"
+\newcommand\reftype{%
+  \@ifstar
+    {\@autoref\@@reftype}%
+    {\@autoref\@reftype}}
+\def\@reftype#1.#2\@nil{#1}
+\def\@@reftype#1.#2\@nil{\@@@reftype#1*\@nil}
+\def\@@@reftype#1*#2\@nil{#1}
+
+% \autoreftype results in the type prose name (plus space character),
+% e.g. "section" in English or "Abschnitt" in German
+% (like \autoref, but without number).
+% \HyPsd@@autorefname is defined in the hyperref package.
+\newcommand*\autoreftype[1]{\@autoref\HyPsd@@autorefname{#1}}
+
+% An alternative version of \autoreftype without space at the end.
+% Since the \space is hard coded inside \HyPsd@@autorefname we use our
+% own version called \@autoreftype instead.
+% Furthermore we offer a starred variant which will work with labels to
+% \section* etc., too.
+\renewcommand*\autoreftype{%
+  \@ifstar
+    {\@autoref\@@autoreftype}%
+    {\@autoref\@autoreftype}}
+\def\@autoreftype#1.#2\@nil{% = \HyPsd@@autorefname without \space
+  \ltx@IfUndefined{#1autorefname}%
+    {\ltx@IfUndefined{#1name}%
+      {}%
+      {\csname#1name\endcsname}}%
+    {\csname#1autorefname\endcsname}}
+\def\@@autoreftype#1.#2\@nil{%
+  \expandafter\@autoreftype\@@@reftype#1*\@nil.\@nil}
+
+\makeatother

--- a/Latex/vorlage/vorlage_subs/custom_commands.tex
+++ b/Latex/vorlage/vorlage_subs/custom_commands.tex
@@ -129,3 +129,9 @@
   \expandafter\@autoreftype\@@@reftype#1*\@nil.\@nil}
 
 \makeatother
+
+% Bezeichnungen Unterabschnitt und Unterunterabschnitt durch Abschnitt ersetzen, auskommentieren, falls diese Bezeichner erwünscht sind
+\AtBeginDocument{%
+  \renewcommand*{\subsectionautorefname}{\sectionautorefname}%
+  \renewcommand*{\subsubsectionautorefname}{\sectionautorefname}%
+}


### PR DESCRIPTION
- literef und fullref finden nun selbst den Typ (Kapitel, Abbildung usw.)
- Abwärtskompatibilität ist gegeben (die alten Commands beziehen sich auf das neue)
- neues command "autoref" generiert `Typ #` (bspw. Unterabschnitt 2.2.3)