### PR TITLE
Neue Positionierung

### DIFF
--- a/HINWEISE.md
+++ b/HINWEISE.md
@@ -101,6 +101,8 @@ Für weitere Details zu Referenzen siehe `Doku-Test.tex` bzw. die standardmäßi
 
 - Soll ein Float unbedingt exakt an der selben Stelle wie im Quellcode platziert werden, kann dies mit `[H]` erzwungen werden (bspw. `\begin{table}[H]`).
 
+- In Floats wird standardmäßig ebenfalls der durch die BA geforderte Zeilenabstand von 1,3 genutzt. Falls hier ein kleinerer Zeilenabstand gewünscht ist, kann dieser manuell per `\linespread{1}` innerhalb des Floats oder global durch Entfernen der zu diesem Zweck in `vorlage.tex` auf `\usepackage{setspace}` folgend eingesetzten Zeilen auf 1 gesetzt werden.
+
 ## Sonstiges
 - Normale Anführungszeichen ("") entsprechen nicht der Deutschen Rechtschreibung. Hierzu das Kommando `\striche{Text}` verwenden.
 

--- a/HINWEISE.md
+++ b/HINWEISE.md
@@ -25,7 +25,7 @@ Für weitere Details zu Referenzen siehe `Doku-Test.tex` bzw. die standardmäßi
     - Nach der Float-Umgebung, muss entweder mit `\footnotetext{Die gewünschte Fußnote}` oder mit `\vgcaption{Link}{Datum}` der entsprechende Fußnotentext gesetzt werden. 
     - Beispiel mit `\vgcaption`:
         ```tex
-        \begin{code}[H]
+        \begin{code}
         \linkcaption{Beispielcode}
         \label{code:example2}
         \end{code}
@@ -33,7 +33,7 @@ Für weitere Details zu Referenzen siehe `Doku-Test.tex` bzw. die standardmäßi
         ```
     - **Besonderheit:** Soll die Fußnote im Text der Caption stehen, ist eine andere Vorgehensweise nötig (ausführlich: https://tex.stackexchange.com/questions/10181/using-footnote-in-a-figures-caption):
         ```tex
-        \begin{code}[H]
+        \begin{code}
         \caption[Caption ohne Fußnote]{Caption mit\footnotemark Fußnote}
         \end{code}
         \footnotetext{Text der Fußnote}
@@ -56,7 +56,7 @@ Für weitere Details zu Referenzen siehe `Doku-Test.tex` bzw. die standardmäßi
 ## Float-Umgebungen (Code, Verzeichnisse, usw.)
 - Soll Programmcode in der Arbeit angezeigt bzw. eingebunden werden so steht dafür nun die Umgebung `\begin{code}` zur Verfügung. Der genaue Syntax ist folgender:
     ```tex
-    \begin{code}[H]
+    \begin{code}
         \inputminted[
             firstline=27,
             lastline=37,
@@ -96,6 +96,10 @@ Für weitere Details zu Referenzen siehe `Doku-Test.tex` bzw. die standardmäßi
     ```
 
 - Die einzelnen Zeilen der Formel werden im Mathemathikmodus geschrieben. Die Legende ebenfalls. Siehe dazu auch das HAWA-Dokument.
+
+- Die Positionierung von Float-Umgebungen wird in der `vorlage.tex` definiert. Standard ist `htbp`, was bedeutet, dass alle "Floats" (Abbildungen, Tabellen, Codes, Formeln, Verzeichnisbäume...) standardmäßig, wenn möglich, "hier" (also an der selben Stelle wie im LaTeX-Code) positioniert werden (h), ansonsten am oberen Ende der Seite (t), ansonsten am Ende Seite (b) oder, notfalls, auf einer Seite voller Floats (p).
+
+- Soll ein Float unbedingt exakt an der selben Stelle wie im Quellcode platziert werden, kann dies mit `[H]` erzwungen werden (bspw. `\begin{table}[H]`).
 
 ## Sonstiges
 - Normale Anführungszeichen ("") entsprechen nicht der Deutschen Rechtschreibung. Hierzu das Kommando `\striche{Text}` verwenden.

--- a/Latex/light/vorlage_light.tex
+++ b/Latex/light/vorlage_light.tex
@@ -84,7 +84,7 @@
   type=code,                         % Name der Umgebung
   types=codes,                       % Erweiterung (\listofschemes)
   float,                               % soll gleiten
-  floatpos=H,
+  floatpos=htbp,
   tocentryentrynumberformat=\bfseries,                        % voreingestellte Gleitparameter
   name=Code,                         % Name in Überschriften
   listname={Programmcodeverzeichnis}, % Listenname
@@ -220,7 +220,7 @@
 
 % ? Ab hier beginnen eigene Befehle um den Umgang zu erleichtern
 \newcommand{\logisch}[1]{$``#1``$}
-\newcommand{\bild}[4][1.0]{\begin{figure}[H]
+\newcommand{\bild}[4][1.0]{\begin{figure}
                       \centering
                       \includegraphics[width=#1\columnwidth]{bilder/#2}
                       \caption{#3}
@@ -229,7 +229,7 @@
 \newcommand{\striche}[1]{\glqq #1\grqq{}}
 \newcommand{\vglink}[2]{\footnote{\hspace{0.5em}vgl.~\href{#1}{#1}~(#2)}}
 \newcommand{\python}[1]{\mintinline{python}{#1}}
-\newcommand{\svg}[4][1.0]{\begin{figure}[H]
+\newcommand{\svg}[4][1.0]{\begin{figure}
   \centering
   \includesvg[width=#1\columnwidth,inkscapelatex=false]{bilder/#2}
   \caption{#3}

--- a/Latex/vorlage/Doku-Test.tex
+++ b/Latex/vorlage/Doku-Test.tex
@@ -18,7 +18,7 @@ Siehe Quelltext.\fn{Dort wird das Kommando \striche{bild} aufgeführt. In dieser
 Siehe Quelltext.
 %\svg[0.5]{dateiname-ohne-endung}{Text zu einer \ac{SVG}-Datei}{label2}
 \section{Programmcode}
-\begin{code}[H]
+\begin{code}
     \begin{minted}{python}
         import asdf
         from foo import bar
@@ -41,7 +41,7 @@ Dies kann genutzt werden, wenn man nur kurz auf eine Funktion eingehen möchte u
 
 Ein weiterer Code um zu schauen, ob danach die Zeilennummerierung wieder funktioniert.
 
-\begin{code}[H]
+\begin{code}
   \begin{minted}{python}
       class Wooo(Foo):
           def __init__(self, boo):
@@ -93,7 +93,7 @@ Ein weiterer Code um zu schauen, ob danach die Zeilennummerierung wieder funktio
 \chapter{Test-/Dokutabelle}
 Diese Tabelle dient hauptsächlich zum Testen der einzelnen Kommandos, sowie als minimales Beispiel für eine \emph{tabularx}-Tabelle:
 \hbadness=10000 %"Tabelle 1" in Spalte Beispiel erzeugt sonst eine Warnung
-\begin{table}[H]
+\begin{table}
 \begin{tabularx}{\columnwidth}{|p{3cm}|X|p{.2\columnwidth}|}
 \hline
 Gegenstand & Beispiel & Befehl \\

--- a/Latex/vorlage/vorlage.tex
+++ b/Latex/vorlage/vorlage.tex
@@ -115,3 +115,7 @@
 
 %? wird am Ende geladen, um einheitliche Spacings sicherzustellen
 \usepackage{setspace}
+%! setzt den Zeilenabstand in Floats (Tabellen, Code-Listings usw.) auf den in LaTeX definierten Wert (statt 1.0)
+\makeatletter
+\let\@xfloat=\latex@xfloat
+\makeatother

--- a/Latex/vorlage/vorlage.tex
+++ b/Latex/vorlage/vorlage.tex
@@ -53,11 +53,15 @@
 \usepackage{amsthm}
 \usepackage{tabularx}
 \usepackage{multirow}
-\usepackage{setspace}
 \usepackage{booktabs}
 \usepackage{svg}
 \usepackage{graphicx}
 \usepackage{float}
+%! floatplacement für Codes muss in minted.tex definiert werden
+\floatplacement{figure}{htbp}
+\floatplacement{table}{htbp}
+\floatplacement{figure}{htbp}
+\floatplacement{formel}{htbp}
 \usepackage[a4paper,lmargin={2.5cm},rmargin={2.5cm},tmargin={2cm},bmargin={2cm}]{geometry}
 \usepackage{lineno}
 \usepackage[T1]{fontenc}
@@ -79,6 +83,7 @@
 
 \usepackage{scrhack} %necessary to use float with scrreprt
 \usepackage{csquotes}
+\usepackage{setspace}
 
 %! Schriftart
 %! Die HAWA schreibt Arial vor, welches in Standard LaTeX-Distributionen nicht mitgeliefert wird. Helvetica ist nahezu identisch.

--- a/Latex/vorlage/vorlage.tex
+++ b/Latex/vorlage/vorlage.tex
@@ -83,7 +83,6 @@
 
 \usepackage{scrhack} %necessary to use float with scrreprt
 \usepackage{csquotes}
-\usepackage{setspace}
 
 %! Schriftart
 %! Die HAWA schreibt Arial vor, welches in Standard LaTeX-Distributionen nicht mitgeliefert wird. Helvetica ist nahezu identisch.
@@ -113,3 +112,6 @@
 
 %! verbesserte Umbrüche (hoffentlich)
 \input{vorlage/vorlage_subs/umbrüche}
+
+%? wird am Ende geladen, um einheitliche Spacings sicherzustellen
+\usepackage{setspace}

--- a/Latex/vorlage/vorlage_subs/custom_commands.tex
+++ b/Latex/vorlage/vorlage_subs/custom_commands.tex
@@ -8,7 +8,7 @@
 % Umgebungen u.Ä.
 \newcommand{\fn}[1]{\footnote{\hspace{0.5em}#1}}
 %! #1 - Breite, #2 - Dateiname, #3 Caption, #4 - Label
-\newcommand{\bild}[4][1.0]{\begin{figure}[H]
+\newcommand{\bild}[4][1.0]{\begin{figure}
   \centering
   \includegraphics[width=#1\columnwidth]{bilder/#2}
   \caption{#3}
@@ -16,14 +16,14 @@
   \end{figure}}
 \newcommand{\striche}[1]{\glqq #1\grqq{}}
 %! #1 - Breite, #2 - Dateiname, #3 Caption, #4 - Label
-\newcommand{\svg}[4][1.0]{\begin{figure}[H]
+\newcommand{\svg}[4][1.0]{\begin{figure}
     \centering
     \includesvg[width=#1\columnwidth,inkscapelatex=false]{bilder/#2}
     \caption{#3}
     \label{#4}
     \end{figure}}
 %! #1 - Dirtree, #2 - Caption, #3 - Label
-\newcommand{\verzeichnis}[3]{\begin{figure}[H]
+\newcommand{\verzeichnis}[3]{\begin{figure}
   % https://tex.stackexchange.com/a/99591/220899
   \renewcommand{\DTstyle}{\textrm\expandafter\raisebox{-0.7ex}}
   \centering
@@ -41,7 +41,7 @@
 \newcommand{\vgcaption}[2]{\footnotetext{\hspace{0.5em}vgl.~\href{#1}{#1}~(#2)}}
 \newcommand{\python}[1]{\mintinline{python}{#1}}
 %! #1 - Formel, #2 - Legende, #3 - Caption, #4 - Label
-\newcommand{\formula}[4]{\begin{formel}[H]
+\newcommand{\formula}[4]{\begin{formel}
   \pretocmd{\captionbelow}{\onelinecaptionstrue}{}{}
   \KOMAoptions{captions=centeredbeside}
   \begin{captionbeside}[#3]{\textbf{#3}}[r]#1\end{captionbeside}

--- a/Latex/vorlage/vorlage_subs/minted.tex
+++ b/Latex/vorlage/vorlage_subs/minted.tex
@@ -32,7 +32,7 @@
   type=code,                           % Name der Umgebung
   types=codes,                         % Erweiterung (\listofschemes)
   float,                               % soll gleiten
-  floatpos=H,
+  floatpos=htbp,
   tocentryentrynumberformat=\bfseries, % voreingestellte Gleitparameter
   name=Code,                           % Name in Überschriften
   listname={Programmcodeverzeichnis},  % Listenname


### PR DESCRIPTION
- Spacing standardmäßig `htbp` (hier, top of page, bottom of page, page of floats)
- einheitliche Stelle, um Positionierung anzupassen (abgesehen von Code... das muss man aus Gründen in der TOC-Definition tun)
- einheitliches Spacing, unabhängig von der Positionierung (weil setspace nach float, tabularx usw. geladen)
- fixes #211 

einen Haken gibt es: das Spacing in allen Floats ist damit einheitlich 1. ich habe noch keinen Weg gefunden, überall z.B. 1.3 einzustellen
Für mich ist das kein Dealbreaker, weil einheitlich und leicht einstellbar.