### PR TITLE
Vorbereitung auf Container-Update

### DIFF
--- a/Latex/vorlage/vorlage.tex
+++ b/Latex/vorlage/vorlage.tex
@@ -3,6 +3,7 @@
 
 \usepackage{silence} %unnötige Warnungen unterdrücken
 \WarningFilter{latex}{You have requested}
+\WarningFilter{microtype}{Unable to apply patch}
 % \WarningFilter{scrlayer-scrpage}{\headheight to low}
 % \WarningFilter{scrlayer-scrpage}{\footheight to low}
 % \WarningFilter{scrlayer-scrpage}{Very small head height detected}


### PR DESCRIPTION
TeXLive 2022 wirft in der aktuellen Konfiguration diese Warnung:
`main.tex:9: warning: [microtype] Unable to apply patch 'footnote'`

Ich war nicht in der Lage, die anders abzustellen.... Fußnoten sehen aber absolut normal aus