### PR TITLE
deprecation warning in github actions beheben

### DIFF
--- a/.github/workflows/document-build.yml
+++ b/.github/workflows/document-build.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v3
       - name: Delete individual artifacts
-        uses: geekyeggo/delete-artifact@v1
+        uses: geekyeggo/delete-artifact@v2
         with:
           # sadly, this doesn't have wildcard support yet
           name: |

--- a/.github/workflows/document-build.yml
+++ b/.github/workflows/document-build.yml
@@ -17,7 +17,7 @@ jobs:
           - main_zustimmung
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Determine container version
         run: echo DOCKER_IMAGE=$(cat .vscode/settings.json | python3 -c "import json, sys; print(json.load(sys.stdin)['vorlage-latex.buildcontainer'])") >> $GITHUB_ENV
       - name: Pull container image
@@ -25,7 +25,7 @@ jobs:
       - name: Build PDF
         run: docker run --rm -v "$GITHUB_WORKSPACE/Latex:/latex" -u $(id -u ${USER}):$(id -g ${USER}) -e DISABLE_DIFFPDF=1 -e DISABLE_SYNCTEX=1 -e TARGET="${{ matrix.target }}" $DOCKER_IMAGE
       - name: Archive PDF
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.target }}.pdf
           path: Latex/${{ matrix.target }}.pdf
@@ -50,13 +50,13 @@ jobs:
           github.event_name == 'push'
           && github.event.before != '0000000000000000000000000000000000000000'
         id: checkout-push
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.before }}
       - name: Checkout pull request base
         if: ${{ github.event_name == 'pull_request' }}
         id: checkout-pull-request
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.base.ref }}
       - name: Stop execution on SetUp fail
@@ -84,7 +84,7 @@ jobs:
           fi
       - name: Download new main.pdf
         if: ${{ env.stop != 'true' }}
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.target }}.pdf
       - name: Generate diff
@@ -97,7 +97,7 @@ jobs:
           fi
       - name: Archive diff PDF
         if: ${{ env.stop != 'true' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.target }}-diff.pdf
           path: ${{ matrix.target }}-diff.pdf
@@ -110,7 +110,7 @@ jobs:
     if: always()
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
       - name: Delete individual artifacts
         uses: geekyeggo/delete-artifact@v1
         with:
@@ -125,7 +125,7 @@ jobs:
       - name: Collect files
         run: mkdir documents && cp **/*.pdf documents
       - name: Upload package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: documents
           path: "documents/*.pdf"


### PR DESCRIPTION
test-run mit diff: https://github.com/ba-latex/Vorlage-Latex/actions/runs/3982069885

closes #225 
(nach dem merge dran denken, auch den `dev-actions-v3-test`-branch zu löschen - https://github.com/ba-latex/Vorlage-Latex/branches)