### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/document-build.yml
+++ b/.github/workflows/document-build.yml
@@ -16,7 +16,7 @@ jobs:
           - main_abstract
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Determine container version
         run: echo DOCKER_IMAGE=$(cat .vscode/settings.json | python3 -c "import json, sys; print(json.load(sys.stdin)['vorlage-latex.buildcontainer'])") >> $GITHUB_ENV
       - name: Pull container image
@@ -24,7 +24,7 @@ jobs:
       - name: Build PDF
         run: docker run --rm -v "$GITHUB_WORKSPACE/Latex:/latex" -u $(id -u ${USER}):$(id -g ${USER}) -e DISABLE_DIFFPDF=1 -e DISABLE_SYNCTEX=1 -e TARGET="${{ matrix.target }}" $DOCKER_IMAGE
       - name: Archive PDF
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}.pdf
           path: Latex/${{ matrix.target }}.pdf
@@ -48,13 +48,13 @@ jobs:
           github.event_name == 'push'
           && github.event.before != '0000000000000000000000000000000000000000'
         id: checkout-push
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.before }}
       - name: Checkout pull request base
         if: ${{ github.event_name == 'pull_request' }}
         id: checkout-pull-request
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
       - name: Stop execution on SetUp fail
@@ -82,7 +82,7 @@ jobs:
           fi
       - name: Download new main.pdf
         if: ${{ env.stop != 'true' }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.target }}.pdf
       - name: Generate diff
@@ -95,7 +95,7 @@ jobs:
           fi
       - name: Archive diff PDF
         if: ${{ env.stop != 'true' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}-diff.pdf
           path: ${{ matrix.target }}-diff.pdf
@@ -108,9 +108,9 @@ jobs:
     if: always()
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: Delete individual artifacts
-        uses: geekyeggo/delete-artifact@v2
+        uses: geekyeggo/delete-artifact@v5
         with:
           # sadly, this doesn't have wildcard support yet
           name: |
@@ -121,7 +121,7 @@ jobs:
       - name: Collect files
         run: mkdir documents && cp **/*.pdf documents
       - name: Upload package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: documents
           path: "documents/*.pdf"


### PR DESCRIPTION
actions/{up,down}load-artifact v3 have long been deprecated and finally broke. none of the breaking changes in v4 should affect us, so this is a drop-in replacement